### PR TITLE
Added DNS lookups as an rule option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,51 +1,52 @@
 {
-    "name": "grunt-localhosts",
-    "description": "Change your local machine hosts",
-    "version": "0.0.8",
-    "homepage": "https://materliu.github.io/grunt-localhosts",
-    "author": {
-        "name": "materliu",
-        "url": "http://materliu.github.com"
+  "name": "grunt-localhosts",
+  "description": "Change your local machine hosts",
+  "version": "0.0.8",
+  "homepage": "https://materliu.github.io/grunt-localhosts",
+  "author": {
+    "name": "materliu",
+    "url": "http://materliu.github.com"
+  },
+  "contributors": [
+    {
+      "name": "materliu",
+      "email": "materliu@gmail.com",
+      "url": "https://materliu.github.com"
     },
-    "contributors": [
-        {
-            "name": "materliu",
-            "email": "materliu@gmail.com",
-            "url": "https://materliu.github.com"
-        },
-        {
-        	"name": "Filip Spiridonov",
-        	"email": "filip.spiridonov@gmail.com",
-        	"url": "https://github.com/NameFILIP"
-        }
-    ],
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/materliu/grunt-localhosts.git"
-    },
-    "scripts": {
-        "test": "./node_modules/mocha/bin/mocha -R spec ./tests"
-    },
-    "bugs": {
-        "url": "https://github.com/materliu/grunt-localhosts/issues"
-    },
-    "engines": {
-        "node": "*"
-    },
-    "main": "localhosts.js",
-    "devDependencies": {
-        "grunt": "~0.4.0",
-        "split": "*",
-        "through": "*",
-        "mocha": "~1.15.1"
-    },
-    "dependencies": {
-        "split": "*",
-        "through": "*"
-    },
-    "keywords": [
-        "gruntplugin",
-        "localhosts",
-        "hosts"
-    ]
+    {
+      "name": "Filip Spiridonov",
+      "email": "filip.spiridonov@gmail.com",
+      "url": "https://github.com/NameFILIP"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/materliu/grunt-localhosts.git"
+  },
+  "scripts": {
+    "test": "./node_modules/mocha/bin/mocha -R spec ./tests"
+  },
+  "bugs": {
+    "url": "https://github.com/materliu/grunt-localhosts/issues"
+  },
+  "engines": {
+    "node": "*"
+  },
+  "main": "localhosts.js",
+  "devDependencies": {
+    "grunt": "~0.4.0",
+    "split": "*",
+    "through": "*",
+    "mocha": "~1.15.1"
+  },
+  "dependencies": {
+    "dns": "^0.2.2",
+    "split": "*",
+    "through": "*"
+  },
+  "keywords": [
+    "gruntplugin",
+    "localhosts",
+    "hosts"
+  ]
 }

--- a/tasks/localhosts.js
+++ b/tasks/localhosts.js
@@ -53,8 +53,7 @@ module.exports = function (grunt) {
     }
     else if (rule && rule.domain) {
       dns.lookup(rule.domain, function (err, address, family) {
-        console.log(address);
-        cb(err, address && address.length && address[0]);
+        cb(err, address);
       });
     }
     else {
@@ -141,6 +140,15 @@ module.exports = function (grunt) {
       grunt.log.writeln('Ready to change localhost!\n');
 
       if (Array.isArray(options.rules)) {
+        var total = 0;
+        var checkComplete = function () {
+          if (total >= options.rules.length) {
+            writeFile(lines, function () {
+              grunt.log.writeln(HOSTS + ' is refreshed');
+              done();
+            });
+          }
+        };
         options.rules.forEach(function (value) {
           getIp(value, function (err, ip) {
             if (err || !ip) {
@@ -160,13 +168,11 @@ module.exports = function (grunt) {
                   break;
               }
             }
+            total++;
+            checkComplete();
           });
         });
-
-        writeFile(lines, function () {
-          grunt.log.writeln(HOSTS + ' is refreshed');
-          done();
-        });
+        checkComplete();
       } else {
         done();
       }

--- a/tasks/localhosts.js
+++ b/tasks/localhosts.js
@@ -8,6 +8,7 @@ module.exports = function (grunt) {
   var fs = require('fs');
   var split = require('split');
   var through = require('through');
+  var dns = require('dns');
 
   const WINDOWS = (process.platform === 'win32');
   const EOL = WINDOWS ? '\r\n' : '\n';
@@ -44,6 +45,21 @@ module.exports = function (grunt) {
         cb(null, lines);
       })
       .on('error', cb);
+  };
+
+  var getIp = function (rule, cb) {
+    if (rule && rule.ip) {
+      cb(null, rule.ip);
+    }
+    else if (rule && rule.domain) {
+      dns.lookup(rule.domain, function (err, address, family) {
+        console.log(address);
+        cb(err, address && address.length && address[0]);
+      });
+    }
+    else {
+      cb("Must specify Ip Address or Domain Name");
+    }
   };
 
   /**
@@ -126,19 +142,25 @@ module.exports = function (grunt) {
 
       if (Array.isArray(options.rules)) {
         options.rules.forEach(function (value) {
-          var ip = value.ip;
-          var hostname = value.hostname;
-          var type = value.type || 'set';
-          switch (type) {
-            case "set":
-              lines = set(lines, ip, hostname);
-              grunt.log.writeln('Set localhost ' + hostname + ' -> ' + ip);
-              break;
-            case "remove":
-              lines = remove(lines, ip, hostname);
-              grunt.log.writeln('Remove localhost ' + hostname + ' -> ' + ip);
-              break;
-          }
+          getIp(value, function (err, ip) {
+            if (err || !ip) {
+              grunt.log.writeln(err || "Could not determine Ip Address!");
+            }
+            else {
+              var hostname = value.hostname;
+              var type = value.type || 'set';
+              switch (type) {
+                case "set":
+                  lines = set(lines, ip, hostname);
+                  grunt.log.writeln('Set localhost ' + hostname + ' -> ' + ip);
+                  break;
+                case "remove":
+                  lines = remove(lines, ip, hostname);
+                  grunt.log.writeln('Remove localhost ' + hostname + ' -> ' + ip);
+                  break;
+              }
+            }
+          });
         });
 
         writeFile(lines, function () {


### PR DESCRIPTION
I had a use case that was great for this npm module except I wanted to point domain "A" to domain "B".

Domain "B" is a dynamic IP due to AWS' loadbalancer IP changing constantly, so I couldn't hard code an Ip Address.

I added the ability to specify a domain instead of a hard coded IP. It will do a dns lookup, then use that IP Address.

Thanks for the tool! Still useful years later.