### PR TITLE
fix(dns): removed npm library and used node API directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "mocha": "~1.15.1"
   },
   "dependencies": {
-    "dns": "^0.2.2",
     "split": "*",
     "through": "*"
   },


### PR DESCRIPTION
The 'dns' library used is very old and does not support node versions greater than 0.8.X
Hence, I have moved this to default node API, which pretty much works exactly in the same way